### PR TITLE
systray: when bottom bar is used with barpadding, toggling the bar draws the systray too low

### DIFF
--- a/dwm/dwm-alpha-systray-6.2.diff
+++ b/dwm/dwm-alpha-systray-6.2.diff
@@ -538,6 +538,7 @@ index 20f8309..55a8297 100644
  	selmon->showbar = !selmon->showbar;
  	updatebarpos(selmon);
  	XMoveResizeWindow(dpy, selmon->barwin, selmon->wx, selmon->by, selmon->ww, bh);
++	int ypad = BAR_PADDING_PATCH ? vp : 0;
 +	if (showsystray) {
 +		XWindowChanges wc;
 +		if (!selmon->showbar)
@@ -545,7 +546,7 @@ index 20f8309..55a8297 100644
 +		else if (selmon->showbar) {
 +			wc.y = 0;
 +			if (!selmon->topbar)
-+				wc.y = selmon->mh - bh;
++				wc.y = selmon->mh - bh + ypad;
 +		}
 +		XConfigureWindow(dpy, systray->win, CWY, &wc);
 +	}
@@ -605,10 +606,10 @@ index 20f8309..55a8297 100644
 +	Monitor *m = systraytomon(NULL);
 +	unsigned int x = m->mx + m->mw;
 +	unsigned int w = 1, xpad = 0, ypad = 0;
-+	#if BARPADDING_PATCH
++	#if BAR_PADDING_PATCH
 +	xpad = sp;
 +	ypad = vp;
-+	#endif // BARPADDING_PATCH
++	#endif // BAR_PADDING_PATCH
 +
 +	if (!showsystray)
 +		return;


### PR DESCRIPTION
I'm not sure if I did this in the most optimized way possible, but the previous patch had a problem where toggling the bar made the systray too low. Also, I see that its called BAR_PADDING_PATCH in patches.def.h, so that might need to be changed too.